### PR TITLE
PR: Implement scheduled notifications for Mass and Confession

### DIFF
--- a/.github/workflows/mass-confession.yml
+++ b/.github/workflows/mass-confession.yml
@@ -1,0 +1,34 @@
+name: Mass & Confession Notifications
+
+on:
+  schedule:
+    # الخميس 9:00 مساءً بتوقيت مصر (19:00 UTC)
+    - cron: '0 19 * * 4'
+    # الجمعة 7:30 صباحاً بتوقيت مصر (05:30 UTC)
+    - cron: '30 5 * * 5'
+    # أول يوم سبت من كل شهر الساعة 10:00 صباحاً (للاعتراف)
+    - cron: '0 8 1-7 * *'
+
+jobs:
+  send-notifications:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Notification API for Mass & Confession
+        run: |
+          # تحديد أي API سيتم طلبه بناءً على الوقت أو اليوم
+          HOUR=$(date +%H)
+          DAY=$(date +%u) # 4=الخميس, 5=الجمعة
+          DOM=$(date +%d) # يوم الشهر
+
+          if [ "$DAY" -eq "4" ] || [ "$DAY" -eq "5" ]; then
+            echo "Triggering Mass Notification..."
+            curl -X GET "${{ secrets.VERCEL_URL }}/api/send-mass-notification" \
+                 -H "Authorization: Bearer ${{ secrets.CRON_SECRET }}"
+          fi
+
+          # إرسال إشعار الاعتراف في أول سبت من الشهر (كمثال ليوم محدد شهرياً)
+          if [ "$DOM" -le 7 ] && [ "$DAY" -eq "6" ]; then
+            echo "Triggering Confession Notification..."
+            curl -X GET "${{ secrets.VERCEL_URL }}/api/send-confession-notification" \
+                 -H "Authorization: Bearer ${{ secrets.CRON_SECRET }}"
+          fi

--- a/app/api/send-confession-notification/route.ts
+++ b/app/api/send-confession-notification/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '@/utils/supabase/server'; // Assuming a Supabase client utility
+
+export async function GET() {
+  try {
+    const supabase = createClient(); // Initialize Supabase client
+
+    // In a real application, you would:
+    // 1. Fetch users who have opted in for monthly Confession notifications from your database.
+    //    Example: const { data: users, error } = await supabase.from('profiles').select('id, push_token').eq('receive_confession_notifications', true);
+    // 2. Iterate through users and send notifications using your preferred notification service.
+    //    Example: await sendPushNotification(user.push_token, { title: 'تذكير بالاعتراف الشهري', body: 'حان وقت الاعتراف الشهري، تواصل مع أب اعترافك.' });
+
+    console.log('Monthly Confession notification trigger received. Initiating notification process...');
+    // Placeholder for actual notification sending logic
+    // await sendConfessionNotificationsToUsers();
+
+    return NextResponse.json({ message: 'Monthly Confession notification process initiated successfully.' }, { status: 200 });
+  } catch (error) {
+    console.error('Error initiating monthly Confession notifications:', error);
+    return NextResponse.json({ error: 'Failed to initiate monthly Confession notifications.' }, { status: 500 });
+  }
+}

--- a/app/api/send-confession-notification/route.ts
+++ b/app/api/send-confession-notification/route.ts
@@ -1,23 +1,38 @@
-import { NextResponse } from 'next/server';
-import { createClient } from '@/utils/supabase/server'; // Assuming a Supabase client utility
+import { NextResponse } from "next/server";
+import { headers } from "next/headers";
 
 export async function GET() {
+  const authHeader = (await headers()).get("authorization");
+  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const confessionMessages = [
+    "«يا ابني اعطني قلبك».. لا تنسَ موعدك مع أب اعترافك هذا الشهر لتجديد قلبك.",
+    "الاعتراف هو غسل للنفس.. حدد موعداً مع أب اعترافك لتنال الحل والراحة.",
+    "فرصة جديدة للبداية.. لا تؤجل اعترافك الدوري، مسيحنا ينتظرك.",
+  ];
+
+  const randomMessage =
+    confessionMessages[Math.floor(Math.random() * confessionMessages.length)];
+
   try {
-    const supabase = createClient(); // Initialize Supabase client
+    await fetch("https://onesignal.com/api/v1/notifications", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json; charset=utf-8",
+        Authorization: `Basic ${process.env.ONESIGNAL_REST_API_KEY}`,
+      },
+      body: JSON.stringify({
+        app_id: process.env.NEXT_PUBLIC_ONESIGNAL_APP_ID,
+        included_segments: ["All"],
+        headings: { en: "تذكير بالاعتراف", ar: "تذكير بالاعتراف" },
+        contents: { en: randomMessage, ar: randomMessage },
+      }),
+    });
 
-    // In a real application, you would:
-    // 1. Fetch users who have opted in for monthly Confession notifications from your database.
-    //    Example: const { data: users, error } = await supabase.from('profiles').select('id, push_token').eq('receive_confession_notifications', true);
-    // 2. Iterate through users and send notifications using your preferred notification service.
-    //    Example: await sendPushNotification(user.push_token, { title: 'تذكير بالاعتراف الشهري', body: 'حان وقت الاعتراف الشهري، تواصل مع أب اعترافك.' });
-
-    console.log('Monthly Confession notification trigger received. Initiating notification process...');
-    // Placeholder for actual notification sending logic
-    // await sendConfessionNotificationsToUsers();
-
-    return NextResponse.json({ message: 'Monthly Confession notification process initiated successfully.' }, { status: 200 });
+    return NextResponse.json({ success: true });
   } catch (error) {
-    console.error('Error initiating monthly Confession notifications:', error);
-    return NextResponse.json({ error: 'Failed to initiate monthly Confession notifications.' }, { status: 500 });
+    return NextResponse.json({ error: "Failed to send confession notification" }, { status: 500 });
   }
 }

--- a/app/api/send-mass-notification/route.ts
+++ b/app/api/send-mass-notification/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '@/utils/supabase/server'; // Assuming a Supabase client utility
+
+export async function GET() {
+  try {
+    const supabase = createClient(); // Initialize Supabase client
+
+    // In a real application, you would:
+    // 1. Fetch users who have opted in for weekly Mass notifications from your database.
+    //    Example: const { data: users, error } = await supabase.from('profiles').select('id, push_token').eq('receive_mass_notifications', true);
+    // 2. Iterate through users and send notifications using your preferred notification service.
+    //    Example: for (const user of users) {
+    //      await sendPushNotification(user.push_token, { title: 'تذكير بالقداس الأسبوعي', body: 'لا تنسَ حضور القداس هذا الأسبوع!' });
+    //    }
+
+    console.log('Weekly Mass notification trigger received. Initiating notification process...');
+    // Placeholder for actual notification sending logic
+    // await sendMassNotificationsToUsers();
+
+    return NextResponse.json({ message: 'Weekly Mass notification process initiated successfully.' }, { status: 200 });
+  } catch (error) {
+    console.error('Error initiating weekly Mass notifications:', error);
+    return NextResponse.json({ error: 'Failed to initiate weekly Mass notifications.' }, { status: 500 });
+  }
+}

--- a/app/api/send-mass-notification/route.ts
+++ b/app/api/send-mass-notification/route.ts
@@ -1,25 +1,42 @@
-import { NextResponse } from 'next/server';
-import { createClient } from '@/utils/supabase/server'; // Assuming a Supabase client utility
+import { NextResponse } from "next/server";
+import { headers } from "next/headers";
 
 export async function GET() {
+  const authHeader = (await headers()).get("authorization");
+  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const hour = new Date().getUTCHours() + 2; // لتوقيت مصر
+
+  const message =
+    hour > 12
+      ? {
+          title: "استعداد للقداس",
+          body: "ينبغي لنا أن نستعد للتناول بالصوم والتوبة.. نلتقي في القداس غداً ✨",
+        }
+      : {
+          title: "صباح البركة",
+          body: "يوم جديد مع المسيح.. حان وقت الذهاب للقداس والتناول من الأسرار المقدسة 🍞🍷",
+        };
+
   try {
-    const supabase = createClient(); // Initialize Supabase client
+    const response = await fetch("https://onesignal.com/api/v1/notifications", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json; charset=utf-8",
+        Authorization: `Basic ${process.env.ONESIGNAL_REST_API_KEY}`,
+      },
+      body: JSON.stringify({
+        app_id: process.env.NEXT_PUBLIC_ONESIGNAL_APP_ID,
+        included_segments: ["All"], 
+        headings: { en: message.title, ar: message.title },
+        contents: { en: message.body, ar: message.body },
+      }),
+    });
 
-    // In a real application, you would:
-    // 1. Fetch users who have opted in for weekly Mass notifications from your database.
-    //    Example: const { data: users, error } = await supabase.from('profiles').select('id, push_token').eq('receive_mass_notifications', true);
-    // 2. Iterate through users and send notifications using your preferred notification service.
-    //    Example: for (const user of users) {
-    //      await sendPushNotification(user.push_token, { title: 'تذكير بالقداس الأسبوعي', body: 'لا تنسَ حضور القداس هذا الأسبوع!' });
-    //    }
-
-    console.log('Weekly Mass notification trigger received. Initiating notification process...');
-    // Placeholder for actual notification sending logic
-    // await sendMassNotificationsToUsers();
-
-    return NextResponse.json({ message: 'Weekly Mass notification process initiated successfully.' }, { status: 200 });
+    return NextResponse.json({ success: true });
   } catch (error) {
-    console.error('Error initiating weekly Mass notifications:', error);
-    return NextResponse.json({ error: 'Failed to initiate weekly Mass notifications.' }, { status: 500 });
+    return NextResponse.json({ error: "Failed to send" }, { status: 500 });
   }
 }


### PR DESCRIPTION
## Summary
This PR introduces two new API routes to support scheduled notifications:
- `/api/send-mass-notification`: Intended to be triggered weekly to remind users about Mass attendance.
- `/api/send-confession-notification`: Intended to be triggered monthly to remind users about confession.

These routes currently contain placeholder logic for fetching opted-in users and sending notifications, assuming an external cron job will call them and a notification service (e.g., push notifications) is available.

## Files Changed
- `app/api/send-mass-notification/route.ts`
- `app/api/send-confession-notification/route.ts`

---
### 📋 Task Details
- **Notion Task**: نضيف اشعار اسبوعي لحضور القداس و شهري للاعتراف


- **Priority**: 🟡 Medium

> 🤖 Auto-generated by Notion → Gemini → GitHub Actions